### PR TITLE
スラッシュコマンド登録スクリプトに`/start`,`/stop`を追加する (vibe-kanban)

### DIFF
--- a/script/deployCommands.ts
+++ b/script/deployCommands.ts
@@ -26,6 +26,8 @@ async function main(): Promise<void> {
 					.setRequired(true),
 			)
 			.toJSON(),
+		new SlashCommandBuilder().setName("start").setDescription("セッションを開始します").toJSON(),
+		new SlashCommandBuilder().setName("stop").setDescription("セッションを終了します").toJSON(),
 	] satisfies RESTPostAPIApplicationCommandsJSONBody[];
 
 	const guildId = process.env.DISCORD_GUILD_ID ?? "";


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新機能
  - スラッシュコマンド「/start」「/stop」を追加
  - 各コマンドに日本語の説明を付与し、補完やヘルプに反映
  - 新コマンドはデプロイ後に利用可能（既存機能への影響なし）

<!-- end of auto-generated comment: release notes by coderabbit.ai -->