### PR TITLE
/start コマンドでセッションタイトルを登録できるようにする (vibe-kanban)

### DIFF
--- a/commands.http
+++ b/commands.http
@@ -1,0 +1,8 @@
+@appId = {{$dotenv DISCORD_APPLICATION_ID}}
+@token = {{$dotenv DISCORD_TOKEN}}
+
+###
+
+GET https://discord.com/api/v10/applications/{{appId}}/commands
+Authorization: Bot {{token}}
+

--- a/script/deployCommands.ts
+++ b/script/deployCommands.ts
@@ -26,7 +26,16 @@ async function main(): Promise<void> {
 					.setRequired(true),
 			)
 			.toJSON(),
-		new SlashCommandBuilder().setName("start").setDescription("セッションを開始します").toJSON(),
+		new SlashCommandBuilder()
+			.setName("start")
+			.setDescription("セッションを開始します")
+			.addStringOption((option) =>
+				option.setName("title").setDescription("セッションのタイトル").setRequired(false),
+			)
+			.addIntegerOption((option) =>
+				option.setName("cadence").setDescription("リマインダーの間隔（分単位）").setRequired(false),
+			)
+			.toJSON(),
 		new SlashCommandBuilder().setName("stop").setDescription("セッションを終了します").toJSON(),
 	] satisfies RESTPostAPIApplicationCommandsJSONBody[];
 

--- a/script/deployCommands.ts
+++ b/script/deployCommands.ts
@@ -30,7 +30,7 @@ async function main(): Promise<void> {
 			.setName("start")
 			.setDescription("セッションを開始します")
 			.addStringOption((option) =>
-				option.setName("title").setDescription("セッションのタイトル").setRequired(false),
+				option.setName("title").setDescription("セッションのタイトル").setRequired(true),
 			)
 			.addIntegerOption((option) =>
 				option.setName("cadence").setDescription("リマインダーの間隔（分単位）").setRequired(false),

--- a/src/hono.ts
+++ b/src/hono.ts
@@ -56,6 +56,17 @@ function getCommandOption(
 	return options?.find((option) => option.name === name);
 }
 
+function getStringOption(options: DiscordCommandOption[] | undefined, name: string): string | null {
+	const option = getCommandOption(options, name);
+	if (!option) {
+		return null;
+	}
+	if (typeof option.value === "string") {
+		return option.value;
+	}
+	return null;
+}
+
 function getNumericOption(
 	options: DiscordCommandOption[] | undefined,
 	name: string,
@@ -134,6 +145,7 @@ app.post("/interactions", async (c) => {
 				});
 			}
 
+			const title = getStringOption(interaction.data?.options, "title") ?? undefined;
 			const cadenceOptionValue = getNumericOption(interaction.data?.options, "cadence");
 			const cadenceMinutes =
 				cadenceOptionValue && cadenceOptionValue > 0 ? Math.floor(cadenceOptionValue) : undefined;
@@ -146,6 +158,7 @@ app.post("/interactions", async (c) => {
 					discordUserId: userId,
 					baseChannelId: channelId,
 					now,
+					title,
 					cadenceMinutes,
 					userDisplayName: interaction.member?.user?.username ?? interaction.user?.username,
 				});

--- a/src/hono.ts
+++ b/src/hono.ts
@@ -145,7 +145,17 @@ app.post("/interactions", async (c) => {
 				});
 			}
 
-			const title = getStringOption(interaction.data?.options, "title") ?? undefined;
+			const title = getStringOption(interaction.data?.options, "title");
+			if (!title) {
+				return c.json({
+					type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
+					data: {
+						content: "セッションのタイトルを入力してください。",
+						flags: EPHEMERAL_FLAG,
+					},
+				});
+			}
+
 			const cadenceOptionValue = getNumericOption(interaction.data?.options, "cadence");
 			const cadenceMinutes =
 				cadenceOptionValue && cadenceOptionValue > 0 ? Math.floor(cadenceOptionValue) : undefined;

--- a/src/lib/discord/interactions/start.ts
+++ b/src/lib/discord/interactions/start.ts
@@ -43,7 +43,7 @@ export interface StartCommandContext {
 	discordUserId: string;
 	baseChannelId: string;
 	now: Date;
-	title?: string;
+	title: string;
 	cadenceMinutes?: number;
 	userDisplayName?: string;
 	sessionId?: string;


### PR DESCRIPTION
`/progress {status}` のように `/start {title}` を登録できるようにする
マイグレーションも必要。
スキーマの管理は `sqlite3def` を使用している。
ベースとなるスキーマは `schema.sql` 開発用のDBは `schema.sqlite`
マイグレーションの実行は私が行うので、私にレビューを依頼するときに聞いてください。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新機能
  - 「/start」コマンドに必須オプション「title（セッションのタイトル）」を追加。未入力時はエラーメッセージで案内。
  - 任意の数値オプション「cadence（リマインダー間隔・分）」を追加。
  - 指定したタイトルが開始処理に反映されるよう改善。
- ドキュメント
  - Discord アプリケーションコマンド一覧を取得するHTTPリクエスト例を追加（環境変数 appId と token を使用）。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->