### PR TITLE
メッセージの通知が飛ぶようにリマインダーはメンションする (vibe-kanban)

### DIFF
--- a/src/jobs/promptScheduler.ts
+++ b/src/jobs/promptScheduler.ts
@@ -93,10 +93,11 @@ async function processDueSession({
 		return;
 	}
 
+	const content = `<@${session.discord_user_id}> ${prompt}`;
 	const discordMessage = await createDiscordMessage({
 		token: discordToken,
 		channelId,
-		content: prompt,
+		content,
 	});
 
 	const createdAt = safeTimestamp(discordMessage.timestamp, scheduled.getTime());

--- a/test/promptScheduler.spec.ts
+++ b/test/promptScheduler.spec.ts
@@ -76,8 +76,7 @@ describe("processPromptSchedulerTick", () => {
 		});
 		mockedCreateDiscordMessage.mockResolvedValue({
 			id: "discord-456",
-			channel_id: dueSession.discord_thread_id,
-			content: "昨日のAI連携の進捗はどうですか？",
+			content: "<@user-1> 昨日のAI連携の進捗はどうですか？",
 			timestamp: "2025-10-02T10:00:05.000Z",
 		});
 
@@ -107,7 +106,7 @@ describe("processPromptSchedulerTick", () => {
 		expect(mockedCreateDiscordMessage).toHaveBeenCalledWith({
 			token: "bot-token",
 			channelId: "thread-99",
-			content: "昨日のAI連携の進捗はどうですか？",
+			content: "<@user-1> 昨日のAI連携の進捗はどうですか？",
 		});
 		expect(mockedInsertMessage).toHaveBeenCalledWith(db, {
 			id: "prompt-message-uuid",


### PR DESCRIPTION
定期的にメッセージをポストしているが、ユーザーに通知が行かない。
メンションをつけることでユーザーに通知が行くようにする。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新機能
  - Discordへの投稿時、対象ユーザーへのメンションを自動付与し、通知と宛先が明確になりました。

- テスト
  - メッセージ内容をメンション形式に合わせてモックを更新。
  - 不要なフィールドを削除し、期待挙動に即した検証に調整。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->