### PR TITLE
進捗報告メッセージには反応しない (vibe-kanban)

### DIFF
--- a/src/hono.ts
+++ b/src/hono.ts
@@ -310,8 +310,6 @@ app.post("/interactions", async (c) => {
 			c.executionCtx.waitUntil(
 				handleProgressCommand({
 					db: c.env.DB,
-					ai: c.env.AI,
-					discordToken: c.env.DISCORD_TOKEN,
 					session,
 					progressText,
 					now,
@@ -327,8 +325,7 @@ app.post("/interactions", async (c) => {
 			return c.json({
 				type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
 				data: {
-					content:
-						"進捗報告ありがとうございます！フィードバックをスレッドに投稿します。少々お待ちください。",
+					content: "進捗を記録しました。",
 					flags: EPHEMERAL_FLAG,
 				},
 			});

--- a/src/lib/discord/interactions/progress.ts
+++ b/src/lib/discord/interactions/progress.ts
@@ -1,13 +1,9 @@
-import { insertMessage, listMessagesForSession } from "../../../data/messageRepository";
+import { insertMessage } from "../../../data/messageRepository";
 import type { MessageRow, SessionRow } from "../../../data/models";
 import { updateSessionAfterUserReply } from "../../../data/sessionRepository";
-import { generateProgressFeedback } from "../../ai/progressFeedback";
-import { createDiscordMessage } from "../api";
 
 export interface ProgressCommandContext {
 	db: D1Database;
-	ai: Ai;
-	discordToken: string;
 	session: SessionRow;
 	progressText: string;
 	now: Date;
@@ -15,23 +11,11 @@ export interface ProgressCommandContext {
 
 export interface ProgressCommandResult {
 	userMessage: MessageRow;
-	botMessage: MessageRow;
-	discordMessageId: string;
 	nextPromptDue: number;
-	model: string;
-}
-
-export class MissingThreadTargetError extends Error {
-	constructor(sessionId: string) {
-		super(`Session ${sessionId} does not have a Discord channel or thread configured`);
-		this.name = "MissingThreadTargetError";
-	}
 }
 
 export async function handleProgressCommand({
 	db,
-	ai,
-	discordToken,
 	session,
 	progressText,
 	now,
@@ -41,7 +25,6 @@ export async function handleProgressCommand({
 		throw new Error("Progress text must not be empty");
 	}
 
-	const history = await listMessagesForSession(db, session.id);
 	const timestamp = now.getTime();
 
 	const userMessage: MessageRow = {
@@ -54,39 +37,6 @@ export async function handleProgressCommand({
 	};
 	await insertMessage(db, userMessage);
 
-	const feedback = await generateProgressFeedback({
-		ai,
-		history: [...history, userMessage],
-		now,
-		userUpdate: normalized,
-	});
-
-	const channelId = session.discord_thread_id ?? session.discord_channel_id;
-	if (!channelId) {
-		throw new MissingThreadTargetError(session.id);
-	}
-
-	const discordResponse = await createDiscordMessage({
-		token: discordToken,
-		channelId,
-		content: feedback.message,
-	});
-
-	const responseTimestamp = discordResponse.timestamp
-		? Date.parse(discordResponse.timestamp)
-		: timestamp;
-	const createdAt = Number.isFinite(responseTimestamp) ? responseTimestamp : timestamp;
-
-	const botMessage: MessageRow = {
-		id: crypto.randomUUID(),
-		session_id: session.id,
-		author: "bot",
-		discord_message_id: discordResponse.id,
-		content: feedback.message,
-		created_at: createdAt,
-	};
-	await insertMessage(db, botMessage);
-
 	const nextPromptDue = timestamp + session.cadence_minutes * 60_000;
 	await updateSessionAfterUserReply(db, session.id, {
 		lastUserReplyAt: timestamp,
@@ -95,9 +45,6 @@ export async function handleProgressCommand({
 
 	return {
 		userMessage,
-		botMessage,
-		discordMessageId: discordResponse.id,
 		nextPromptDue,
-		model: feedback.model,
 	};
 }

--- a/test/progressInteraction.spec.ts
+++ b/test/progressInteraction.spec.ts
@@ -2,46 +2,28 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("../src/data/messageRepository", () => ({
 	insertMessage: vi.fn(),
-	listMessagesForSession: vi.fn(),
 }));
 
 vi.mock("../src/data/sessionRepository", () => ({
 	updateSessionAfterUserReply: vi.fn(),
 }));
 
-vi.mock("../src/lib/ai/progressFeedback", () => ({
-	generateProgressFeedback: vi.fn(),
-}));
-
-vi.mock("../src/lib/discord/api", () => ({
-	createDiscordMessage: vi.fn(),
-}));
-
-import { insertMessage, listMessagesForSession } from "../src/data/messageRepository";
+import { insertMessage } from "../src/data/messageRepository";
 import type { SessionRow } from "../src/data/models";
 import { updateSessionAfterUserReply } from "../src/data/sessionRepository";
-import { generateProgressFeedback } from "../src/lib/ai/progressFeedback";
-import type { WorkersAiBinding } from "../src/lib/ai/progressPrompt";
-import { createDiscordMessage } from "../src/lib/discord/api";
 import { handleProgressCommand } from "../src/lib/discord/interactions/progress";
 
 describe("handleProgressCommand", () => {
-	const mockedListMessages = vi.mocked(listMessagesForSession);
 	const mockedInsertMessage = vi.mocked(insertMessage);
 	const mockedUpdateSession = vi.mocked(updateSessionAfterUserReply);
-	const mockedGenerateFeedback = vi.mocked(generateProgressFeedback);
-	const mockedCreateDiscordMessage = vi.mocked(createDiscordMessage);
 
 	beforeEach(() => {
 		vi.restoreAllMocks();
-		mockedListMessages.mockReset();
 		mockedInsertMessage.mockReset();
 		mockedUpdateSession.mockReset();
-		mockedGenerateFeedback.mockReset();
-		mockedCreateDiscordMessage.mockReset();
 	});
 
-	it("persists the user update, generates feedback, posts to Discord, and updates the session schedule", async () => {
+	it("persists the user update and updates the session schedule", async () => {
 		const session: SessionRow = {
 			id: "session-1",
 			discord_user_id: "user-1",
@@ -57,83 +39,27 @@ describe("handleProgressCommand", () => {
 		};
 
 		const now = new Date("2025-10-02T10:00:00.000Z");
-		const history = [
-			{
-				id: "message-0",
-				session_id: session.id,
-				author: "bot" as const,
-				discord_message_id: "discord-old",
-				content: "進捗どうですか？",
-				created_at: Date.UTC(2025, 9, 2, 9, 20, 0),
-			},
-		];
-		mockedListMessages.mockResolvedValue(history);
-
-		const feedbackMessage =
-			"昨日の署名検証を終えて順調ですね！次のAI統合の進み具合を教えてください。";
-		mockedGenerateFeedback.mockResolvedValue({
-			message: feedbackMessage,
-			usage: { prompt_tokens: 120, completion_tokens: 64, total_tokens: 184 },
-			model: "@cf/meta/llama-3.1-8b-instruct",
-		});
-
-		mockedCreateDiscordMessage.mockResolvedValue({
-			id: "discord-123",
-			channel_id: session.discord_thread_id,
-			content: feedbackMessage,
-			timestamp: "2025-10-02T10:00:02.000Z",
-		});
 
 		const uuidSpy = vi
 			.spyOn(globalThis.crypto, "randomUUID")
-			.mockReturnValueOnce("user-message-uuid")
-			.mockReturnValueOnce("bot-message-uuid");
+			.mockReturnValueOnce("user-message-uuid");
 
 		const db = {} as D1Database;
-		const aiBinding = { run: vi.fn() } as unknown as WorkersAiBinding;
 
 		const result = await handleProgressCommand({
 			db,
-			ai: aiBinding,
-			discordToken: "bot-token",
 			session,
 			progressText: "署名検証が完了したのでAI連携に着手しました",
 			now,
 		});
 
-		expect(mockedListMessages).toHaveBeenCalledWith(db, session.id);
-
-		expect(mockedInsertMessage).toHaveBeenNthCalledWith(1, db, {
+		expect(mockedInsertMessage).toHaveBeenCalledWith(db, {
 			id: "user-message-uuid",
 			session_id: session.id,
 			author: "user",
 			discord_message_id: null,
 			content: "署名検証が完了したのでAI連携に着手しました",
 			created_at: now.getTime(),
-		});
-
-		expect(mockedGenerateFeedback).toHaveBeenCalledWith({
-			ai: aiBinding,
-			history: expect.arrayContaining([
-				expect.objectContaining({ id: "user-message-uuid", author: "user" }),
-			]),
-			now,
-			userUpdate: "署名検証が完了したのでAI連携に着手しました",
-		});
-
-		expect(mockedCreateDiscordMessage).toHaveBeenCalledWith({
-			token: "bot-token",
-			channelId: "thread-1",
-			content: feedbackMessage,
-		});
-
-		expect(mockedInsertMessage).toHaveBeenNthCalledWith(2, db, {
-			id: "bot-message-uuid",
-			session_id: session.id,
-			author: "bot",
-			discord_message_id: "discord-123",
-			content: feedbackMessage,
-			created_at: Date.parse("2025-10-02T10:00:02.000Z"),
 		});
 
 		expect(mockedUpdateSession).toHaveBeenCalledWith(db, session.id, {
@@ -143,13 +69,7 @@ describe("handleProgressCommand", () => {
 
 		expect(result).toEqual({
 			userMessage: expect.objectContaining({ id: "user-message-uuid" }),
-			botMessage: expect.objectContaining({
-				id: "bot-message-uuid",
-				discord_message_id: "discord-123",
-			}),
-			discordMessageId: "discord-123",
 			nextPromptDue: now.getTime() + session.cadence_minutes * 60_000,
-			model: "@cf/meta/llama-3.1-8b-instruct",
 		});
 
 		uuidSpy.mockRestore();


### PR DESCRIPTION
進捗報告メッセージに毎回レスポンスされると目障りなので、進捗報告にはレスポンスしない。

つまり、 /progress {status} は記録するだけで createMessage は行わない

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 仕様変更
  * 進捗コマンドの応答を「進捗を記録しました。」に簡素化。
  * ボットのAIフィードバック表示とDiscordへの自動投稿を停止。以後は記録完了メッセージのみを返します。

* テスト
  * 進捗コマンドのテストを簡素化し、ユーザー更新の保存処理のみを検証。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->